### PR TITLE
Add reply metadata flag when replying

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -66,6 +66,7 @@ module.exports = function(config,callback){
     }
     if(config.in_reply_to){
       reqOptions.form.in_reply_to_status_id = tweet.id_str
+      reqOptions.form.auto_populate_reply_metadata = true;
     }
     request.post(reqOptions,function(err,res,body){
       try {


### PR DESCRIPTION
Hey, thanks for sharing this; even years later, I got it to work fairly easily with a couple of tweaks! Here’s one, and I’ll submit the other in a separate PR since it’s not directly related.

Referencing [this documentation on tweet creation](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update#parameters), the description for `in_reply_to_status_id` mentions:

> This parameter will be ignored unless the author of the Tweet this parameter references is mentioned within the status text. Therefore, you must include `@username`, where `username` is the author of the referenced Tweet, within the update.

Using `auto_populate_reply_metadata` does that automatically:

> If set to `true` and used with `in_reply_to_status_id`, leading `@mentions` will be looked up from the original Tweet, and added to the new Tweet from there.