### PR TITLE
Move last-reply-setting inside match conditional

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -86,9 +86,9 @@ module.exports = function(config,callback){
   twitter.stream('statuses/filter', {'track':keywords}, function(stream) {
     stream.on('data',function(tweet){
       if(!lastReplied || ((new Date().getTime() - lastReplied) > maxRepliesMs)){
-        lastReplied = new Date().getTime()
         var matches = tweet.text.match(match)
         if(matches){
+          lastReplied = new Date().getTime()
           postReply(getReply(tweet,matches),tweet,function(err,response){
             if(err) logger.error("Got error posting tweet: ",err.message," with response:",response);
           })


### PR DESCRIPTION
It doesn’t make sense to store the last replied date if the
tweet being examined doesn’t match and therefore produce
a reply.